### PR TITLE
Ensures correct previous state return

### DIFF
--- a/src/Events/StatusUpdated.php
+++ b/src/Events/StatusUpdated.php
@@ -44,6 +44,6 @@ class StatusUpdated
      */
     public function getPreviousState() : string
     {
-        return $this->previous_state;
+        return $this->previous_state ?? '';
     }
 }


### PR DESCRIPTION
If no previous state exists and so, not passed on when triggering the event, we now make sure that there is an expected string return.